### PR TITLE
Rename sink filters for code clarity (API changes!)

### DIFF
--- a/cmd/example-several-outputs/main.go
+++ b/cmd/example-several-outputs/main.go
@@ -25,21 +25,21 @@ func main() {
 	// Each output allows filter out any records and write any other.
 	// You specify filter for the keys (key filter).
 	// Each of these keys should be presented in the record.
-	errors.WithKey("error", "msg")
+	errors.HasKey("error", "msg")
 	// The filter may take into account key values. So only records with levels
 	// ERROR and FATAL will be passed filter and written to stderr.
-	errors.WithValue("level", "ERROR", "FATAL").Start()
+	errors.HasValue("level", "ERROR", "FATAL").Start()
 
 	// Vice versa you can filter out some keys.
-	info.WithoutKey("error")
+	info.HasNotKey("error")
 	// And define another set of key-val pairs for distinguish outputs.
-	info.WithValue("level", "INFO", "WARNING").Start()
+	info.HasValue("level", "INFO", "WARNING").Start()
 
 	// It will output all records from outputs above if they have key "something".
 	// So you can duplicate some records to several log files based on some criteria.
-	something.WithKey("something").Start()
+	something.HasKey("something").Start()
 
-	// So if you not define any clauses (WithKey/WithoutKey/WithValue/WithoutValues)
+	// So if you not define any clauses (HasKey/HasNotKey/HasValue/WithoutValues)
 	// then all records will copied to an output.
 
 	// Let's go!

--- a/filter.go
+++ b/filter.go
@@ -2,7 +2,7 @@ package kiwi
 
 // This file consists of implementations of Filter interface.
 
-/* Copyright (c) 2016, Alexander I.Grafov <grafov@gmail.com>
+/* Copyright (c) 2016-2019, Alexander I.Grafov <grafov@gmail.com>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/sink.go
+++ b/sink.go
@@ -116,9 +116,9 @@ func SinkTo(w io.Writer, fn Formatter) *Sink {
 	return sink
 }
 
-// WithKey sets restriction for records output.
+// HasKey sets restriction for records output.
 // Only the records WITH any of the keys will be passed to output.
-func (s *Sink) WithKey(keys ...string) *Sink {
+func (s *Sink) HasKey(keys ...string) *Sink {
 	if atomic.LoadInt32(s.state) > sinkClosed {
 		s.Lock()
 		for _, key := range keys {
@@ -130,9 +130,9 @@ func (s *Sink) WithKey(keys ...string) *Sink {
 	return s
 }
 
-// WithoutKey sets restriction for records output.
+// HasNotKey sets restriction for records output.
 // Only the records WITHOUT any of the keys will be passed to output.
-func (s *Sink) WithoutKey(keys ...string) *Sink {
+func (s *Sink) HasNotKey(keys ...string) *Sink {
 	if atomic.LoadInt32(s.state) > sinkClosed {
 		s.Lock()
 		for _, key := range keys {
@@ -144,11 +144,11 @@ func (s *Sink) WithoutKey(keys ...string) *Sink {
 	return s
 }
 
-// WithValue sets restriction for records output.
+// HasValue sets restriction for records output.
 // A record passed to output if the key equal one of any of the listed values.
-func (s *Sink) WithValue(key string, vals ...string) *Sink {
+func (s *Sink) HasValue(key string, vals ...string) *Sink {
 	if len(vals) == 0 {
-		return s.WithKey(key)
+		return s.HasKey(key)
 	}
 	if atomic.LoadInt32(s.state) > sinkClosed {
 		s.Lock()
@@ -159,10 +159,10 @@ func (s *Sink) WithValue(key string, vals ...string) *Sink {
 	return s
 }
 
-// WithoutValue sets restriction for records output.
-func (s *Sink) WithoutValue(key string, vals ...string) *Sink {
+// HasNotValue sets restriction for records output.
+func (s *Sink) HasNotValue(key string, vals ...string) *Sink {
 	if len(vals) == 0 {
-		return s.WithoutKey(key)
+		return s.HasNotKey(key)
 	}
 	if atomic.LoadInt32(s.state) > sinkClosed {
 		s.Lock()
@@ -173,8 +173,8 @@ func (s *Sink) WithoutValue(key string, vals ...string) *Sink {
 	return s
 }
 
-// WithInt64Range sets restriction for records output.
-func (s *Sink) WithInt64Range(key string, from, to int64) *Sink {
+// Int64Range sets restriction for records output.
+func (s *Sink) Int64Range(key string, from, to int64) *Sink {
 	if atomic.LoadInt32(s.state) > sinkClosed {
 		s.Lock()
 		delete(s.negativeFilters, key)
@@ -184,8 +184,8 @@ func (s *Sink) WithInt64Range(key string, from, to int64) *Sink {
 	return s
 }
 
-// WithoutInt64Range sets restriction for records output.
-func (s *Sink) WithoutInt64Range(key string, from, to int64) *Sink {
+// Int64NotRange sets restriction for records output.
+func (s *Sink) Int64NotRange(key string, from, to int64) *Sink {
 	if atomic.LoadInt32(s.state) > sinkClosed {
 		s.Lock()
 		delete(s.positiveFilters, key)
@@ -195,8 +195,8 @@ func (s *Sink) WithoutInt64Range(key string, from, to int64) *Sink {
 	return s
 }
 
-// WithFloat64Range sets restriction for records output.
-func (s *Sink) WithFloat64Range(key string, from, to float64) *Sink {
+// Float64Range sets restriction for records output.
+func (s *Sink) Float64Range(key string, from, to float64) *Sink {
 	if atomic.LoadInt32(s.state) > sinkClosed {
 		s.Lock()
 		delete(s.negativeFilters, key)
@@ -206,8 +206,8 @@ func (s *Sink) WithFloat64Range(key string, from, to float64) *Sink {
 	return s
 }
 
-// WithoutFloat64Range sets restriction for records output.
-func (s *Sink) WithoutFloat64Range(key string, from, to float64) *Sink {
+// Float64NotRange sets restriction for records output.
+func (s *Sink) Float64NotRange(key string, from, to float64) *Sink {
 	if atomic.LoadInt32(s.state) > sinkClosed {
 		s.Lock()
 		delete(s.positiveFilters, key)
@@ -217,8 +217,8 @@ func (s *Sink) WithoutFloat64Range(key string, from, to float64) *Sink {
 	return s
 }
 
-// WithTimeRange sets restriction for records output.
-func (s *Sink) WithTimeRange(key string, from, to time.Time) *Sink {
+// TimeRange sets restriction for records output.
+func (s *Sink) TimeRange(key string, from, to time.Time) *Sink {
 	if atomic.LoadInt32(s.state) > sinkClosed {
 		s.Lock()
 		delete(s.negativeFilters, key)
@@ -228,8 +228,8 @@ func (s *Sink) WithTimeRange(key string, from, to time.Time) *Sink {
 	return s
 }
 
-// WithoutTimeRange sets restriction for records output.
-func (s *Sink) WithoutTimeRange(key string, from, to time.Time) *Sink {
+// TimeNotRange sets restriction for records output.
+func (s *Sink) TimeNotRange(key string, from, to time.Time) *Sink {
 	if atomic.LoadInt32(s.state) > sinkClosed {
 		s.Lock()
 		delete(s.positiveFilters, key)


### PR DESCRIPTION
With/Without name prefixes in the sink filters intesects with the
names of the functions that handles context With() and
Without(). Has/HasNot is more clear here.