### PR TITLE
Fix (*Sink).Close()

### DIFF
--- a/sink.go
+++ b/sink.go
@@ -306,7 +306,6 @@ func (s *Sink) Start() *Sink {
 
 // Close closes the sink. It flushes records for the sink before closing.
 func (s *Sink) Close() {
-	return
 	if atomic.LoadInt32(s.state) > sinkClosed {
 		atomic.StoreInt32(s.state, sinkClosed)
 		s.close <- struct{}{}


### PR DESCRIPTION
The `return` in here seems a mistake added in 43e2faec2d5e84144caf7e3e199729abfb21568e

fixes #4 

cc @grafov @eric